### PR TITLE
fix: fixes package for older build pipelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
 	"name": "@renumerate/js",
 	"private": false,
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"type": "module",
-	"main": "dist/renumerate.cjs.js",
-	"module": "dist/renumerate.es.js",
+	"main": "./dist/renumerate.cjs.js",
+	"module": "./dist/renumerate.es.js",
+	"types": "./dist/core.d.ts",
 	"exports": {
 		".": {
 			"types": "./dist/core.d.ts",
@@ -38,6 +39,9 @@
 		"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"files": [
-		"dist"
+		"dist",
+    "react.js",
+    "react.cjs",
+    "react.d.ts"
 	]
 }

--- a/react.cjs
+++ b/react.cjs
@@ -1,0 +1,1 @@
+module.exports = require("./dist/react/index.cjs.js");

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/react";

--- a/react.js
+++ b/react.js
@@ -1,0 +1,1 @@
+export * from "./dist/react/index.es.js";


### PR DESCRIPTION
### TL;DR

Added React subpath exports and improved package exports configuration to work with older node module resolution.

### What changed?

- Added explicit `types` field in package.json pointing to `./dist/core.d.ts`
- Added leading `./` to main and module paths for better compatibility
- Created React-specific entry points:
  - `react.js` (ESM)
  - `react.cjs` (CommonJS)
  - `react.d.ts` (TypeScript definitions)
- Updated the `files` array to include these new React entry point files