### PR TITLE
chore: add customer_email parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ Ensure the following:
 
 This process securely creates a session ID for the customer cancellation flow.
 
+**Request Body Parameters:**
+
+When generating a retention session, you must include either the `customer_id` or `customer_email` (or both). Below is a table of all available parameters:
+
 | key                          | type                        | notes                                   |
 | ---------------------------- | --------------------------- | --------------------------------------- |
 | cancellation                 | object                      |                                         |
-| cancellation.customer_id     | string                      | Your stripe customerId                  |
+| cancellation.customer_id     | string \| undefined         | Your stripe customerId                  |
+| cancellation.customer_email  | string \| undefined         | The customer's email address in stripe  |
 | cancellation.subscription_id | string \| undefined         | The specific subscription id (optional) |
 | cancellation.subscriberData  | { string: any } \ undefined | Object of subscriber data (optional)    |
 
@@ -87,10 +92,16 @@ Ensure the following:
 
 This process securely creates a session ID for the customer cancellation flow.
 
+
+**Request Body Parameters:**
+
+When generating a SubscriptionHub session, you must include either the `customer_id` or `customer_email` (or both). Below is a table of all available parameters:
+
 | key                          | type                | notes                                   |                                      |
 | ---------------------------- | ------------------- | --------------------------------------- | ------------------------------------ |
 | subscription                 | object              |                                         |                                      |
-| subscription.customer_id     | string              | Your stripe customerId                  |                                      |
+| subscription.customer_id     | string \| undefined | Your stripe customerId                  |                                      |
+| cancellation.customer_email  | string \| undefined | The customer's email address in stripe  |
 | subscription.subscription_id | string \| undefined | The specific subscription id (optional) |                                      |
 
 Here's an example Node.js flow to obtain customer's session id:


### PR DESCRIPTION
### TL;DR

Added support for customer email identification in the retention session API.

### What changed?

- Updated the README documentation to include `customer_email` as an alternative parameter for identifying customers when generating a retention session
- Modified the `customer_id` type from `string` to `string | undefined` to indicate it's optional when email is provided
- Added a clarifying note that either `customer_id` or `customer_email` (or both) must be included in the request

### How to test?

1. Generate a retention session using only a customer email instead of customer ID
2. Verify the session is created successfully
3. Test with both parameters provided to ensure backward compatibility

### Why make this change?

This change provides more flexibility in customer identification, allowing systems that primarily track customers by email address to use the retention flow without requiring a customer ID lookup.