### PR TITLE
fix(ui): make retention modals smaller in width

### DIFF
--- a/packages/renumerate/dist/renumerate.cjs.js
+++ b/packages/renumerate/dist/renumerate.cjs.js
@@ -12,7 +12,7 @@
 			.renumerate-dialog {
 				position: fixed;
 				margin: 0 auto;
-				width: 800px;
+				width: 412px;
 				max-width: 90%;
 				height: 100%;
 				display: flex;
@@ -58,14 +58,14 @@
 				border-radius: 8px;
 				background-color: #fcfbf9;
 				box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-				min-width: 653px;
+				min-width: 412px;
 			}
 
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
 				min-height: 160px;
-				min-width: 600px;
+				min-width: 412x;
 				border: none;
 				margin: 0;
 				padding: 0;

--- a/packages/renumerate/dist/renumerate.es.js
+++ b/packages/renumerate/dist/renumerate.es.js
@@ -161,7 +161,7 @@ class a {
 			.renumerate-dialog {
 				position: fixed;
 				margin: 0 auto;
-				width: 800px;
+				width: 412px;
 				max-width: 90%;
 				height: 100%;
 				display: flex;
@@ -207,14 +207,14 @@ class a {
 				border-radius: 8px;
 				background-color: #fcfbf9;
 				box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-				min-width: 653px;
+				min-width: 412px;
 			}
 
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
 				min-height: 160px;
-				min-width: 600px;
+				min-width: 412x;
 				border: none;
 				margin: 0;
 				padding: 0;

--- a/packages/renumerate/dist/renumerate.umd.js
+++ b/packages/renumerate/dist/renumerate.umd.js
@@ -12,7 +12,7 @@
 			.renumerate-dialog {
 				position: fixed;
 				margin: 0 auto;
-				width: 800px;
+				width: 412px;
 				max-width: 90%;
 				height: 100%;
 				display: flex;
@@ -58,14 +58,14 @@
 				border-radius: 8px;
 				background-color: #fcfbf9;
 				box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-				min-width: 653px;
+				min-width: 412px;
 			}
 
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
 				min-height: 160px;
-				min-width: 600px;
+				min-width: 412x;
 				border: none;
 				margin: 0;
 				padding: 0;

--- a/packages/renumerate/lib/core.ts
+++ b/packages/renumerate/lib/core.ts
@@ -323,7 +323,7 @@ export class Renumerate {
 			.renumerate-dialog {
 				position: fixed;
 				margin: 0 auto;
-				width: 800px;
+				width: 412px;
 				max-width: 90%;
 				height: 100%;
 				display: flex;
@@ -369,14 +369,14 @@ export class Renumerate {
 				border-radius: 8px;
 				background-color: #fcfbf9;
 				box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
-				min-width: 653px;
+				min-width: 412px;
 			}
 
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
 				min-height: 160px;
-				min-width: 600px;
+				min-width: 412x;
 				border: none;
 				margin: 0;
 				padding: 0;


### PR DESCRIPTION
### TL;DR

Reduced the width of the Renumerate dialog to make it match the new designs.

### What changed?

- Decreased the dialog width from 800px to 412px
- Reduced the minimum width from 653px to 412px
- Changed the iframe minimum width from 600px to 412px