### PR TITLE
fix: make modal initial size the same as first component size

### DIFF
--- a/packages/renumerate/dist/renumerate.cjs.js
+++ b/packages/renumerate/dist/renumerate.cjs.js
@@ -64,7 +64,7 @@
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
-				min-height: 160px;
+				min-height: 304px;
 				min-width: 412x;
 				border: none;
 				margin: 0;

--- a/packages/renumerate/dist/renumerate.es.js
+++ b/packages/renumerate/dist/renumerate.es.js
@@ -213,7 +213,7 @@ class a {
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
-				min-height: 160px;
+				min-height: 304px;
 				min-width: 412x;
 				border: none;
 				margin: 0;

--- a/packages/renumerate/dist/renumerate.umd.js
+++ b/packages/renumerate/dist/renumerate.umd.js
@@ -64,7 +64,7 @@
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
-				min-height: 160px;
+				min-height: 304px;
 				min-width: 412x;
 				border: none;
 				margin: 0;

--- a/packages/renumerate/lib/core.ts
+++ b/packages/renumerate/lib/core.ts
@@ -375,7 +375,7 @@ export class Renumerate {
 			.renumerate-dialog-content iframe {
 				width: 100%;
 				height: 100%;
-				min-height: 160px;
+				min-height: 304px;
 				min-width: 412x;
 				border: none;
 				margin: 0;

--- a/packages/renumerate/package.json
+++ b/packages/renumerate/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@renumerate/js",
 	"private": false,
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"type": "module",
 	"main": "./dist/renumerate.cjs.js",
 	"module": "./dist/renumerate.es.js",


### PR DESCRIPTION
### TL;DR

Increased the minimum height of the iframe in the dialog content and bumped package version. This stops the component from "building" from small to large on render